### PR TITLE
1.18 fabric 157

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,18 +3,18 @@ name: PullRequest Test
 on:
   pull_request:
     branches:
-      - "1.17-fabric"
+      - "1.18-fabric"
 
 jobs:
   pr-check:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/kotori316/fictional-meme/fictional-meme:1.18.1
+      credentials:
+        username: kotori316
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 16
-        uses: actions/setup-java@v2
-        with:
-          java-version: 16
-          distribution: 'adopt'
       - name: Test
-        run: chmod +x ./gradlew && ./gradlew build --stacktrace --no-daemon --warning-mode all
+        run: chmod +x ./gradlew && ./gradlew build --stacktrace --no-daemon

--- a/src/main/scala/com/yogpc/qp/machines/quarry/Target.java
+++ b/src/main/scala/com/yogpc/qp/machines/quarry/Target.java
@@ -47,6 +47,7 @@ public abstract class Target {
                 if (QuarryPlus.config.common.debug) {
                     throw new IllegalArgumentException("Invalid target nbt. " + tag);
                 } else {
+                    QuarryPlus.LOGGER.error("Invalid target nbt in Quarry Target. %s".formatted(tag));
                     yield null;
                 }
             }

--- a/src/main/scala/com/yogpc/qp/machines/quarry/Target.java
+++ b/src/main/scala/com/yogpc/qp/machines/quarry/Target.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.yogpc.qp.QuarryPlus;
 import com.yogpc.qp.machines.Area;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -42,7 +43,13 @@ public abstract class Target {
             case "FrameTarget" -> FrameTarget.from(tag);
             case "PosesTarget" -> PosesTarget.from(tag);
             case "FrameInsideTarget" -> FrameInsideTarget.from(tag);
-            default -> throw new IllegalArgumentException("Invalid target nbt. " + tag);
+            default -> {
+                if (QuarryPlus.config.common.debug) {
+                    throw new IllegalArgumentException("Invalid target nbt. " + tag);
+                } else {
+                    yield null;
+                }
+            }
         };
     }
 

--- a/src/main/scala/com/yogpc/qp/machines/quarry/Target.java
+++ b/src/main/scala/com/yogpc/qp/machines/quarry/Target.java
@@ -28,7 +28,13 @@ public abstract class Target {
     public abstract Stream<BlockPos> allPoses();
 
     @NotNull
-    public abstract CompoundTag toNbt();
+    protected abstract CompoundTag toNbt();
+
+    public static CompoundTag toNbt(Target target) {
+        var tag = target.toNbt();
+        tag.putString("target", target.getClass().getSimpleName());
+        return tag;
+    }
 
     public static Target fromNbt(CompoundTag tag) {
         return switch (tag.getString("target")) {
@@ -135,7 +141,6 @@ final class DigTarget extends Target {
     @NotNull
     public CompoundTag toNbt() {
         var tag = new CompoundTag();
-        tag.putString("target", getClass().getSimpleName());
         tag.put("area", area.toNBT());
         tag.putInt("y", y);
         if (currentTarget != null) tag.putLong("currentTarget", currentTarget.asLong());
@@ -219,7 +224,6 @@ final class FrameTarget extends Target {
     @NotNull
     public CompoundTag toNbt() {
         var tag = new CompoundTag();
-        tag.putString("target", getClass().getSimpleName());
         tag.put("area", area.toNBT());
         tag.putLong("currentTarget", Objects.requireNonNullElse(currentTarget, new BlockPos(area.minX(), area.maxY(), area.minZ() + 1)).asLong());
 
@@ -297,7 +301,6 @@ final class PosesTarget extends Target {
     @Override
     public @NotNull CompoundTag toNbt() {
         var tag = new CompoundTag();
-        tag.putString("target", getClass().getSimpleName());
         var list = new LongArrayTag(allPoses().mapToLong(BlockPos::asLong).toArray());
         tag.put("poses", list);
         return tag;

--- a/src/main/scala/com/yogpc/qp/machines/quarry/Target.java
+++ b/src/main/scala/com/yogpc/qp/machines/quarry/Target.java
@@ -271,7 +271,7 @@ final class PosesTarget extends Target {
             currentTarget = iterator.next();
     }
 
-    public static PosesTarget from(CompoundTag tag) {
+    static PosesTarget from(CompoundTag tag) {
         var poses = Arrays.stream(tag.getLongArray("poses")).mapToObj(BlockPos::of).toList();
         return new PosesTarget(poses);
     }

--- a/src/main/scala/com/yogpc/qp/machines/quarry/TileQuarry.java
+++ b/src/main/scala/com/yogpc/qp/machines/quarry/TileQuarry.java
@@ -12,13 +12,13 @@ import com.yogpc.qp.QuarryPlus;
 import com.yogpc.qp.machines.Area;
 import com.yogpc.qp.machines.BreakResult;
 import com.yogpc.qp.machines.CheckerLog;
-import com.yogpc.qp.packet.ClientSync;
 import com.yogpc.qp.machines.EnchantmentLevel;
 import com.yogpc.qp.machines.EnergyConfigAccessor;
 import com.yogpc.qp.machines.ItemConverter;
 import com.yogpc.qp.machines.MachineStorage;
 import com.yogpc.qp.machines.PowerTile;
 import com.yogpc.qp.machines.QPBlock;
+import com.yogpc.qp.packet.ClientSync;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
@@ -71,8 +71,9 @@ public class TileQuarry extends PowerTile implements ClientSync, CheckerLog, Mac
 
     @Override
     public void saveAdditional(CompoundTag nbt) {
-        if (target != null)
-            nbt.put("target", target.toNbt());
+        if (target != null) {
+            nbt.put("target", Target.toNbt(target));
+        }
         nbt.putString("state", state.name());
         if (area != null)
             nbt.put("area", area.toNBT());

--- a/src/test/java/com/yogpc/qp/machines/quarry/TargetTest.java
+++ b/src/test/java/com/yogpc/qp/machines/quarry/TargetTest.java
@@ -8,16 +8,21 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.yogpc.qp.QuarryPlus;
 import com.yogpc.qp.machines.Area;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -189,6 +194,26 @@ class TargetTest {
         void FrameInsideTargetTest() {
             var target = new FrameInsideTarget(area, area.minY(), area.maxY());
             serializeTest(target);
+        }
+
+        @Test
+        void throwErrorIfEmpty() {
+            var tag = new CompoundTag();
+            assertThrows(IllegalArgumentException.class,
+                () -> Target.fromNbt(tag));
+        }
+
+        @Test
+        void notThrowIfNonDebug() {
+            var before = QuarryPlus.config.common.debug;
+            QuarryPlus.config.common.debug = false;
+            try {
+                var target = assertDoesNotThrow(() -> Target.fromNbt(new CompoundTag()),
+                    "Safe fast in real environment.");
+                assertNull(target);
+            } finally {
+                QuarryPlus.config.common.debug = before;
+            }
         }
     }
 }

--- a/src/test/java/com/yogpc/qp/machines/quarry/TargetTest.java
+++ b/src/test/java/com/yogpc/qp/machines/quarry/TargetTest.java
@@ -1,14 +1,17 @@
 package com.yogpc.qp.machines.quarry;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.yogpc.qp.machines.Area;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -126,5 +129,59 @@ class TargetTest {
     void pos2Str3() {
         var str = Target.posToStr(new BlockPos(-1, -54, 8));
         assertEquals("{x=-1, y=-54, z=8}", str);
+    }
+
+    @Nested
+    class SerializeTest {
+        private static void serializeTest(Target target) {
+            var allPoses = target.allPoses().collect(Collectors.toSet());
+
+            var tag = target.toNbt();
+            var deserialized = Target.fromNbt(tag);
+            var poses = deserialized.allPoses().collect(Collectors.toSet());
+            assertEquals(allPoses, poses);
+        }
+
+        @Test
+        void DigTargetTest() {
+            var target = new DigTarget(area, area.maxY() - 1);
+            serializeTest(target);
+        }
+
+        @Test
+        void FrameTargetTest1() {
+            var target = new FrameTarget(area);
+            serializeTest(target);
+        }
+
+        @Test
+        void FrameTargetTest2() {
+            var target = new FrameTarget(area, new BlockPos(2, 3, 4));
+            serializeTest(target);
+        }
+
+        @Test
+        void PosesTargetTest1() {
+            var target = new PosesTarget(List.of());
+            serializeTest(target);
+        }
+
+        @Test
+        void PosesTargetTest2() {
+            var target = new PosesTarget(List.of(BlockPos.ZERO, new BlockPos(1, 2, 3)));
+            serializeTest(target);
+        }
+
+        @Test
+        void PosesTargetTest3() {
+            var target = new PosesTarget(Area.getFramePosStream(area).toList());
+            serializeTest(target);
+        }
+
+        @Test
+        void FrameInsideTargetTest() {
+            var target = new FrameInsideTarget(area, area.minY(), area.maxY());
+            serializeTest(target);
+        }
     }
 }

--- a/src/test/java/com/yogpc/qp/machines/quarry/TargetTest.java
+++ b/src/test/java/com/yogpc/qp/machines/quarry/TargetTest.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 import com.yogpc.qp.machines.Area;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.Tag;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -136,10 +137,16 @@ class TargetTest {
         private static void serializeTest(Target target) {
             var allPoses = target.allPoses().collect(Collectors.toSet());
 
-            var tag = target.toNbt();
-            var deserialized = Target.fromNbt(tag);
-            var poses = deserialized.allPoses().collect(Collectors.toSet());
-            assertEquals(allPoses, poses);
+            {
+                var tag = target.toNbt();
+                assertFalse(tag.contains("target", Tag.TAG_STRING));
+            }
+            {
+                var tag = Target.toNbt(target);
+                var deserialized = Target.fromNbt(tag);
+                var poses = deserialized.allPoses().collect(Collectors.toSet());
+                assertEquals(allPoses, poses);
+            }
         }
 
         @Test


### PR DESCRIPTION
Close #157 

Quarry has several modes, and there is a mode called "FrameInsideTarget". A crash happens if your world tries to load a world where quarry with "FrameInsideTarget" exists, because quarry can't load nbt correctly due to bugs in saving nbt.

I added some codes to make sure the target name is saved to nbt. Also, quarry will not throw exception if quarry failed to load target nbt.