### PR TITLE
1.18 ftb chunks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,21 +181,21 @@ repositories {
             includeModule("com.blamejared.crafttweaker", "CraftTweaker-1.16.4")
         }
     }
-    maven {
-        name = "FTB OLD"
-        url = "https://maven.latmod.com/"
-        content {
-            includeModule("com.feed_the_beast.mods", "ftb-chunks")
-            includeModule("com.feed_the_beast.mods", "ftb-gui-library")
-        }
-    }
 
     maven {
         name = "FTB NEW"
         url = "https://maven.saps.dev/minecraft/"
         content {
-            includeModule("dev.ftb.mods", "ftb-chunks-forge")
-            includeModule("dev.ftb.mods", "ftb-library-forge")
+            includeGroup("dev.ftb.mods")
+            includeGroup("dev.latvian.mods")
+        }
+    }
+
+    maven {
+        name = "architectury"
+        url = uri("https://maven.architectury.dev/")
+        content {
+            it.includeGroup("dev.architectury")
         }
     }
 
@@ -229,6 +229,13 @@ dependencies {
     runtimeOnly(group: "com.kotori316", name: "ScalableCatsForce".toLowerCase(), version: project.slpVersion, classifier: "with-library") {
         transitive(false)
     }
+
+    // FTB Chunks stuff
+    implementation(fg.deobf(group: "dev.ftb.mods", name: "ftb-chunks-forge", version: project.ftbChunksVersion))
+    implementation(fg.deobf(group: "dev.ftb.mods", name: "ftb-library-forge", version: project.ftbLibraryVersion))
+    runtimeOnly(fg.deobf(group: "dev.ftb.mods", name: "ftb-teams-forge", version: project.ftbTeamsVersion))
+    runtimeOnly(fg.deobf(group: "dev.ftb.mods", name: "ftb-teams-forge", version: project.ftbTeamsVersion))
+    runtimeOnly(fg.deobf(group: "dev.architectury", name: "architectury-forge", version: project.architecturyVersion))
 
     // Test Dependencies.
     final def JUPITER_VERSION = '5.8.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,11 @@ catsVersion=2.8.1-kotori
 slpVersion=2.13.8-build-4
 # https://dev.azure.com/Kotori316/minecraft/_artifacts/feed/mods/maven/com.kotori316%2Ftest_utility/18.2.2/versions
 testUtilVersion=18.2.5
+# https://maven.saps.dev/minecraft/dev/ftb/mods/ftb-chunks-forge
+ftbChunksVersion=1802.3.6-build.145
+# https://maven.saps.dev/minecraft/dev/ftb/mods/ftb-library-forge
+ftbLibraryVersion=1802.3.6-build.120
+# https://maven.saps.dev/minecraft/dev/ftb/mods/ftb-teams-forge
+ftbTeamsVersion=1802.2.6-build.51
+# https://maven.architectury.dev/dev/architectury/architectury-forge/
+architecturyVersion=4.1.34

--- a/src/main/resources/assets/quarryplus/lang/en_us.json
+++ b/src/main/resources/assets/quarryplus/lang/en_us.json
@@ -1,6 +1,5 @@
 {
   "FD.UNKNOWN": "UNKNOWN Direction",
-  "quarryplus.chat.warn_protected_area": "Area contains protected chunks. Quarry has stopped.",
   "FD.down": "DOWN",
   "FD.east": "EAST",
   "FD.north": "NORTH",
@@ -110,6 +109,7 @@
   "quarryplus.chat.quarry.restart": "Quarry Restarted",
   "quarryplus.chat.quarry_mode": "Quarry Mode",
   "quarryplus.chat.warn_area": "[QuarryPlus] Area is too small.",
+  "quarryplus.chat.warn_protected_area": "Area contains protected chunks. Quarry has stopped.",
   "quarryplus.chat.y_level": "Quarry digs to %s.",
   "quarryplus.client.tooltip": "Client",
   "quarryplus.gui.advpump.delete_false": "Delete Off",

--- a/src/main/resources/assets/quarryplus/lang/en_us.json
+++ b/src/main/resources/assets/quarryplus/lang/en_us.json
@@ -1,5 +1,6 @@
 {
   "FD.UNKNOWN": "UNKNOWN Direction",
+  "quarryplus.chat.warn_protected_area": "Area contains protected chunks. Quarry has stopped.",
   "FD.down": "DOWN",
   "FD.east": "EAST",
   "FD.north": "NORTH",

--- a/src/main/resources/assets/quarryplus/lang/fr_fr.json
+++ b/src/main/resources/assets/quarryplus/lang/fr_fr.json
@@ -109,6 +109,7 @@
   "quarryplus.chat.quarry.restart": "Carrière Relancée",
   "quarryplus.chat.quarry_mode": "Mode Carrière",
   "quarryplus.chat.warn_area": "[QuarryPlus] Area is too small.",
+  "quarryplus.chat.warn_protected_area": "Area contains protected chunks. Quarry has stopped.",
   "quarryplus.chat.y_level": "La Carrière creuse à %s.",
   "quarryplus.client.tooltip": "Client",
   "quarryplus.gui.advpump.delete_false": "Effacer Inactif",

--- a/src/main/resources/assets/quarryplus/lang/ja_jp.json
+++ b/src/main/resources/assets/quarryplus/lang/ja_jp.json
@@ -109,6 +109,7 @@
   "quarryplus.chat.quarry.restart": "クァーリーが再開しました。",
   "quarryplus.chat.quarry_mode": "クァーリーモード",
   "quarryplus.chat.warn_area": "[QuarryPlus] 採掘エリアが狭すぎます。",
+  "quarryplus.chat.warn_protected_area": "保護されたチャンクが採掘範囲に含まれているため動作を中止します",
   "quarryplus.chat.y_level": "この機械はy=%sまで採掘します。",
   "quarryplus.client.tooltip": "クライアントの設定",
   "quarryplus.gui.advpump.delete_false": "Delete Off",

--- a/src/main/resources/assets/quarryplus/lang/ko_kr.json
+++ b/src/main/resources/assets/quarryplus/lang/ko_kr.json
@@ -109,6 +109,7 @@
   "quarryplus.chat.quarry.restart": "쿼리 재시작됨",
   "quarryplus.chat.quarry_mode": "쿼리 모드",
   "quarryplus.chat.warn_area": "[QuarryPlus] 영역이 너무 작습니다.",
+  "quarryplus.chat.warn_protected_area": "Area contains protected chunks. Quarry has stopped.",
   "quarryplus.chat.y_level": "쿼리가 %s(으)로 팝니다.",
   "quarryplus.client.tooltip": "클라이언트",
   "quarryplus.gui.advpump.delete_false": "삭제 끄기",

--- a/src/main/resources/assets/quarryplus/lang/ru_ru.json
+++ b/src/main/resources/assets/quarryplus/lang/ru_ru.json
@@ -109,6 +109,7 @@
   "quarryplus.chat.quarry.restart": "Quarry Restarted",
   "quarryplus.chat.quarry_mode": "Режим карьера",
   "quarryplus.chat.warn_area": "[QuarryPlus] Area is too small.",
+  "quarryplus.chat.warn_protected_area": "Area contains protected chunks. Quarry has stopped.",
   "quarryplus.chat.y_level": "Quarry digs to %s.",
   "quarryplus.client.tooltip": "Client",
   "quarryplus.gui.advpump.delete_false": "Delete Off",

--- a/src/main/resources/assets/quarryplus/lang/zh_cn.json
+++ b/src/main/resources/assets/quarryplus/lang/zh_cn.json
@@ -109,6 +109,7 @@
   "quarryplus.chat.quarry.restart": "采石场已重启",
   "quarryplus.chat.quarry_mode": "采石场模式",
   "quarryplus.chat.warn_area": "[QuarryPlus] Area is too small.",
+  "quarryplus.chat.warn_protected_area": "Area contains protected chunks. Quarry has stopped.",
   "quarryplus.chat.y_level": "采石场挖掘到 %s。",
   "quarryplus.client.tooltip": "客户端",
   "quarryplus.gui.advpump.delete_false": "删除关闭",

--- a/src/main/scala/com/yogpc/qp/Config.java
+++ b/src/main/scala/com/yogpc/qp/Config.java
@@ -50,6 +50,7 @@ public class Config {
         public final ForgeConfigSpec.BooleanValue removeCommonMaterialsByCD;
         public final ForgeConfigSpec.BooleanValue reduceMarkerGuideLineIfPlayerIsFar;
         public final ForgeConfigSpec.BooleanValue removeFrameAfterQuarryIsRemoved;
+        public final ForgeConfigSpec.BooleanValue allowWorkInClaimedChunkByFBTChunks;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> spawnerBlackList;
 
         public Common(ForgeConfigSpec.Builder builder) {
@@ -66,6 +67,7 @@ public class Config {
             removeCommonMaterialsByCD = builder.comment("Remove common materials(Stone, Dirt, Grass, Sand) obtained by Chunk Destroyer").define("removeCommonMaterialsByCD", true);
             reduceMarkerGuideLineIfPlayerIsFar = builder.comment("Remove MarkerPlus guide line if player is too far from the marker.").define("reduceMarkerGuideLineIfPlayerIsFar", false);
             removeFrameAfterQuarryIsRemoved = builder.comment("Remove adjacent frames when quarry is removed.").define("removeFrameAfterQuarryIsRemoved", false);
+            allowWorkInClaimedChunkByFBTChunks = builder.comment("Allow quarries to work in claimed chunk(FTB Chunks).").define("allowWorkInClaimedChunkByFBTChunks", false);
             builder.pop();
         }
     }

--- a/src/main/scala/com/yogpc/qp/integration/ftbchunks/FTBChunksProtectionCheck.java
+++ b/src/main/scala/com/yogpc/qp/integration/ftbchunks/FTBChunksProtectionCheck.java
@@ -1,0 +1,45 @@
+package com.yogpc.qp.integration.ftbchunks;
+
+import java.util.Locale;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+
+import com.yogpc.qp.QuarryPlus;
+import com.yogpc.qp.machines.Area;
+import dev.ftb.mods.ftbchunks.data.FTBChunksAPI;
+import dev.ftb.mods.ftblibrary.math.ChunkDimPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.fml.ModList;
+
+public final class FTBChunksProtectionCheck {
+    public static boolean isAreaProtected(Area area, ResourceKey<Level> dimension) {
+        if (QuarryPlus.config.common.allowWorkInClaimedChunkByFBTChunks.get()) {
+            return false;
+        }
+        if (ModList.get().isLoaded("FtbChunks".toLowerCase(Locale.ROOT))) {
+            return Accessor.doesAreaHasProtectedChunk(area, dimension);
+        } else {
+            return false;
+        }
+    }
+
+    static boolean doesAreaHasProtectedChunk(Area area, Predicate<ChunkPos> predicate) {
+        return IntStream.rangeClosed(area.minX() / 16, area.maxX() / 16).boxed()
+            .flatMap(x -> IntStream.rangeClosed(area.minZ() / 16, area.maxZ() / 16).boxed()
+                .map(z -> new ChunkPos(x, z)))
+            .distinct()
+            .anyMatch(predicate);
+    }
+
+    private static final class Accessor {
+        private static boolean isProtected(ResourceKey<Level> dimension, ChunkPos chunkPos) {
+            return FTBChunksAPI.getManager().getChunk(new ChunkDimPos(dimension, chunkPos)) != null;
+        }
+
+        private static boolean doesAreaHasProtectedChunk(Area area, ResourceKey<Level> dimension) {
+            return FTBChunksProtectionCheck.doesAreaHasProtectedChunk(area, c -> isProtected(dimension, c));
+        }
+    }
+}

--- a/src/main/scala/com/yogpc/qp/integration/ftbchunks/FTBChunksProtectionCheck.java
+++ b/src/main/scala/com/yogpc/qp/integration/ftbchunks/FTBChunksProtectionCheck.java
@@ -3,6 +3,7 @@ package com.yogpc.qp.integration.ftbchunks;
 import java.util.Locale;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import com.yogpc.qp.QuarryPlus;
 import com.yogpc.qp.machines.Area;
@@ -26,11 +27,14 @@ public final class FTBChunksProtectionCheck {
     }
 
     static boolean doesAreaHasProtectedChunk(Area area, Predicate<ChunkPos> predicate) {
+        return getChunkPosStream(area).anyMatch(predicate);
+    }
+
+    static Stream<ChunkPos> getChunkPosStream(Area area) {
         return IntStream.rangeClosed(area.minX() / 16, area.maxX() / 16).boxed()
             .flatMap(x -> IntStream.rangeClosed(area.minZ() / 16, area.maxZ() / 16).boxed()
                 .map(z -> new ChunkPos(x, z)))
-            .distinct()
-            .anyMatch(predicate);
+            .distinct();
     }
 
     private static final class Accessor {

--- a/src/main/scala/com/yogpc/qp/machines/Area.java
+++ b/src/main/scala/com/yogpc/qp/machines/Area.java
@@ -19,6 +19,15 @@ public record Area(int minX, int minY, int minZ, int maxX, int maxY, int maxZ,
     @Serial
     private static final long serialVersionUID = 1L;
 
+    public Area {
+        if (minX > maxX)
+            throw new IllegalArgumentException("MinX(%d) must be less than or equal to MaxX(%d)".formatted(minX, maxX));
+        if (minY > maxY)
+            throw new IllegalArgumentException("MinY(%d) must be less than or equal to MaxY(%d)".formatted(minY, maxY));
+        if (minZ > maxZ)
+            throw new IllegalArgumentException("MinZ(%d) must be less than or equal to MaxZ(%d)".formatted(minZ, maxZ));
+    }
+
     public Area(Vec3i pos1, Vec3i pos2, Direction direction) {
         this(Math.min(pos1.getX(), pos2.getX()), Math.min(pos1.getY(), pos2.getY()), Math.min(pos1.getZ(), pos2.getZ()),
             Math.max(pos1.getX(), pos2.getX()), Math.max(pos1.getY(), pos2.getY()), Math.max(pos1.getZ(), pos2.getZ()), direction);
@@ -38,6 +47,19 @@ public record Area(int minX, int minY, int minZ, int maxX, int maxY, int maxZ,
         } else {
             return this;
         }
+    }
+
+    public Area shrink(int x, int y, int z) {
+        int x1 = minX + x;
+        int x2 = maxX - x;
+        int y1 = minY + y;
+        int y2 = maxY - y;
+        int z1 = minZ + z;
+        int z2 = maxZ - z;
+        return new Area(
+            Math.min(x1, x2), Math.min(y1, y2), Math.min(z1, z2),
+            Math.max(x1, x2), Math.max(y1, y2), Math.max(z1, z2),
+            direction);
     }
 
     public boolean isInAreaIgnoreY(Vec3i vec3i) {

--- a/src/main/scala/com/yogpc/qp/machines/advquarry/AdvActionMessage.java
+++ b/src/main/scala/com/yogpc/qp/machines/advquarry/AdvActionMessage.java
@@ -2,6 +2,7 @@ package com.yogpc.qp.machines.advquarry;
 
 import java.util.function.Supplier;
 
+import com.yogpc.qp.integration.ftbchunks.FTBChunksProtectionCheck;
 import com.yogpc.qp.machines.Area;
 import com.yogpc.qp.packet.IMessage;
 import com.yogpc.qp.packet.PacketHandler;
@@ -9,6 +10,7 @@ import com.yogpc.qp.utils.MapMulti;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
@@ -60,7 +62,13 @@ public final class AdvActionMessage implements IMessage {
                 .flatMap(MapMulti.optCast(TileAdvQuarry.class))
                 .ifPresent(quarry -> {
                     switch (message.action) {
-                        case CHANGE_RANGE -> quarry.area = message.area;
+                        case CHANGE_RANGE -> {
+                            quarry.area = message.area;
+                            if (FTBChunksProtectionCheck.isAreaProtected(message.area.shrink(1, 0, 1), quarry.getTargetWorld().dimension())) {
+                                PacketHandler.getPlayer(supplier.get())
+                                    .ifPresent(p -> p.displayClientMessage(new TranslatableComponent("quarryplus.chat.warn_protected_area"), false));
+                            }
+                        }
                         case MODULE_INV -> PacketHandler.getPlayer(supplier.get())
                             .flatMap(MapMulti.optCast(ServerPlayer.class))
                             .ifPresent(quarry::openModuleGui);

--- a/src/main/scala/com/yogpc/qp/machines/advquarry/AdvActionMessage.java
+++ b/src/main/scala/com/yogpc/qp/machines/advquarry/AdvActionMessage.java
@@ -72,7 +72,9 @@ public final class AdvActionMessage implements IMessage {
                         case MODULE_INV -> PacketHandler.getPlayer(supplier.get())
                             .flatMap(MapMulti.optCast(ServerPlayer.class))
                             .ifPresent(quarry::openModuleGui);
-                        case QUICK_START -> quarry.setAction(new AdvQuarryAction.BreakBlock(quarry));
+                        case QUICK_START -> {
+                            if (quarry.canStartWork()) quarry.setAction(new AdvQuarryAction.BreakBlock(quarry));
+                        }
                     }
                 }));
     }

--- a/src/main/scala/com/yogpc/qp/machines/advquarry/AdvQuarryAction.java
+++ b/src/main/scala/com/yogpc/qp/machines/advquarry/AdvQuarryAction.java
@@ -105,7 +105,7 @@ public abstract class AdvQuarryAction implements BlockEntityTicker<TileAdvQuarry
 
         @Override
         public void tick(Level level, BlockPos pos, BlockState state, TileAdvQuarry quarry) {
-            if (quarry.getEnergy() > quarry.getMaxEnergy() / 4) {
+            if (quarry.getEnergy() > quarry.getMaxEnergy() / 4 && quarry.canStartWork()) {
                 quarry.setAction(new MakeFrame(quarry.getArea()));
             }
         }
@@ -190,8 +190,8 @@ public abstract class AdvQuarryAction implements BlockEntityTicker<TileAdvQuarry
             return pos -> {
                 var state = world.getBlockState(pos);
                 return state.is(Holder.BLOCK_FRAME) // Frame
-                    || !quarry.canBreak(world, pos, state) // Unbreakable
-                    || pos.equals(quarry.getBlockPos()) // This machine
+                       || !quarry.canBreak(world, pos, state) // Unbreakable
+                       || pos.equals(quarry.getBlockPos()) // This machine
                     ;
             };
         }

--- a/src/main/scala/com/yogpc/qp/machines/advquarry/BlockAdvQuarry.java
+++ b/src/main/scala/com/yogpc/qp/machines/advquarry/BlockAdvQuarry.java
@@ -5,6 +5,7 @@ import java.util.stream.Stream;
 
 import com.yogpc.qp.Holder;
 import com.yogpc.qp.QuarryPlus;
+import com.yogpc.qp.integration.ftbchunks.FTBChunksProtectionCheck;
 import com.yogpc.qp.integration.wrench.WrenchItems;
 import com.yogpc.qp.machines.Area;
 import com.yogpc.qp.machines.EnchantedLootFunction;
@@ -21,6 +22,7 @@ import com.yogpc.qp.packet.PacketHandler;
 import com.yogpc.qp.utils.CombinedBlockEntityTicker;
 import com.yogpc.qp.utils.MapMulti;
 import com.yogpc.qp.utils.QuarryChunkLoadUtil;
+import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.TranslatableComponent;
@@ -128,6 +130,8 @@ public class BlockAdvQuarry extends QPBlock implements EntityBlock {
                 enchantment.sort(EnchantmentLevel.QUARRY_ENCHANTMENT_COMPARATOR);
                 quarry.initialSetting(enchantment);
                 quarry.area = findArea(level, pos, facing.getOpposite(), quarry.getStorage()::addItem);
+                if (entity != null && FTBChunksProtectionCheck.isAreaProtected(quarry.area.shrink(1, 0, 1), quarry.getTargetWorld().dimension()))
+                    entity.sendMessage(new TranslatableComponent("quarryplus.chat.warn_protected_area"), Util.NIL_UUID);
                 var preForced = QuarryChunkLoadUtil.makeChunkLoaded(level, pos, quarry.enabled);
                 quarry.setChunkPreLoaded(preForced);
                 PacketHandler.sendToClient(new ClientSyncMessage(quarry), level);

--- a/src/main/scala/com/yogpc/qp/machines/advquarry/TileAdvQuarry.java
+++ b/src/main/scala/com/yogpc/qp/machines/advquarry/TileAdvQuarry.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 
 import com.yogpc.qp.Holder;
 import com.yogpc.qp.QuarryPlus;
+import com.yogpc.qp.integration.ftbchunks.FTBChunksProtectionCheck;
 import com.yogpc.qp.machines.Area;
 import com.yogpc.qp.machines.BreakResult;
 import com.yogpc.qp.machines.CheckerLog;
@@ -209,6 +210,10 @@ public class TileAdvQuarry extends PowerTile implements
     @Override
     public List<EnchantmentLevel> getEnchantments() {
         return this.enchantments;
+    }
+
+    public boolean canStartWork() {
+        return area != null && !FTBChunksProtectionCheck.isAreaProtected(area.shrink(1, 0, 1), getTargetWorld().dimension());
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")

--- a/src/main/scala/com/yogpc/qp/machines/quarry/QuarryBlock.java
+++ b/src/main/scala/com/yogpc/qp/machines/quarry/QuarryBlock.java
@@ -5,6 +5,7 @@ import java.util.stream.Stream;
 
 import com.yogpc.qp.Holder;
 import com.yogpc.qp.QuarryPlus;
+import com.yogpc.qp.integration.ftbchunks.FTBChunksProtectionCheck;
 import com.yogpc.qp.integration.wrench.WrenchItems;
 import com.yogpc.qp.machines.Area;
 import com.yogpc.qp.machines.Direction8;
@@ -85,7 +86,10 @@ public class QuarryBlock extends QPBlock implements EntityBlock {
                 quarry.setEnchantments(EnchantmentHelper.getEnchantments(stack));
                 quarry.setTileDataFromItem(BlockItem.getBlockEntityData(stack));
                 var area = findArea(level, pos, facing.getOpposite(), quarry.storage::addItem);
-                if (area.maxX() - area.minX() > 1 && area.maxZ() - area.minZ() > 1) {
+                if (FTBChunksProtectionCheck.isAreaProtected(area, level.dimension())) {
+                    if (entity instanceof Player player)
+                        player.displayClientMessage(new TranslatableComponent("quarryplus.chat.warn_protected_area"), false);
+                } else if (area.maxX() - area.minX() > 1 && area.maxZ() - area.minZ() > 1) {
                     quarry.setState(QuarryState.WAITING, state.setValue(BlockStateProperties.FACING, facing));
                     quarry.setArea(area);
                 } else {

--- a/src/main/scala/com/yogpc/qp/machines/quarry/SFQuarryBlock.java
+++ b/src/main/scala/com/yogpc/qp/machines/quarry/SFQuarryBlock.java
@@ -2,6 +2,7 @@ package com.yogpc.qp.machines.quarry;
 
 import com.yogpc.qp.Holder;
 import com.yogpc.qp.QuarryPlus;
+import com.yogpc.qp.integration.ftbchunks.FTBChunksProtectionCheck;
 import com.yogpc.qp.integration.wrench.WrenchItems;
 import com.yogpc.qp.machines.MachineStorage;
 import com.yogpc.qp.machines.PowerTile;
@@ -70,7 +71,10 @@ public final class SFQuarryBlock extends QPBlock implements EntityBlock {
             if (level.getBlockEntity(pos) instanceof SFQuarryEntity quarry) {
                 quarry.setTileDataFromItem(null);
                 var area = QuarryBlock.findArea(level, pos, facing.getOpposite(), quarry.storage::addItem);
-                if (area.maxX() - area.minX() > 1 && area.maxZ() - area.minZ() > 1) {
+                if (FTBChunksProtectionCheck.isAreaProtected(area, level.dimension())) {
+                    if (entity instanceof Player player)
+                        player.displayClientMessage(new TranslatableComponent("quarryplus.chat.warn_protected_area"), false);
+                } else if (area.maxX() - area.minX() > 1 && area.maxZ() - area.minZ() > 1) {
                     quarry.setState(QuarryState.WAITING, state.setValue(BlockStateProperties.FACING, facing));
                     quarry.setArea(area);
                 } else {

--- a/src/test/java/com/yogpc/qp/integration/ftbchunks/FTBChunksProtectionCheckTest.java
+++ b/src/test/java/com/yogpc/qp/integration/ftbchunks/FTBChunksProtectionCheckTest.java
@@ -1,0 +1,68 @@
+package com.yogpc.qp.integration.ftbchunks;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.yogpc.qp.machines.Area;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.ChunkPos;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FTBChunksProtectionCheckTest {
+    @Nested
+    class ChunkPosStreamTest {
+        @ParameterizedTest
+        @ValueSource(ints = {0, 1, 15, 16, 100, -1, -64})
+        void justOne1(int maxY) {
+            Area area = new Area(0, -64, 0, 0, maxY, 0, Direction.NORTH);
+            var chunkPoses = FTBChunksProtectionCheck.getChunkPosStream(area).collect(Collectors.toSet());
+
+            assertEquals(Set.of(new ChunkPos(0, 0)), chunkPoses);
+        }
+
+        @Test
+        void justOne2() {
+            Area area = new Area(0, 0, 0, 15, 0, 0, Direction.NORTH);
+            var chunkPoses = FTBChunksProtectionCheck.getChunkPosStream(area).collect(Collectors.toSet());
+
+            assertEquals(Set.of(new ChunkPos(0, 0)), chunkPoses);
+        }
+
+        @Test
+        void x2() {
+            Area area = new Area(0, 0, 0, 16, 0, 0, Direction.NORTH);
+            var chunkPoses = FTBChunksProtectionCheck.getChunkPosStream(area).collect(Collectors.toSet());
+
+            assertEquals(Set.of(new ChunkPos(0, 0), new ChunkPos(1, 0)), chunkPoses);
+        }
+
+        @Test
+        void z2() {
+            Area area = new Area(0, 0, 0, 0, 0, 16, Direction.NORTH);
+            var chunkPoses = FTBChunksProtectionCheck.getChunkPosStream(area).collect(Collectors.toSet());
+
+            assertEquals(Set.of(new ChunkPos(0, 0), new ChunkPos(0, 1)), chunkPoses);
+        }
+
+        @Test
+        void xz1() {
+            Area area = new Area(0, 0, 0, 15, 0, 15, Direction.NORTH);
+            var chunkPoses = FTBChunksProtectionCheck.getChunkPosStream(area).collect(Collectors.toSet());
+
+            assertEquals(Set.of(new ChunkPos(0, 0)), chunkPoses);
+        }
+
+        @Test
+        void xz2() {
+            Area area = new Area(0, 0, 0, 16, 0, 16, Direction.NORTH);
+            var chunkPoses = FTBChunksProtectionCheck.getChunkPosStream(area).collect(Collectors.toSet());
+
+            assertEquals(Set.of(new ChunkPos(0, 0), new ChunkPos(0, 1), new ChunkPos(1, 0), new ChunkPos(1, 1)), chunkPoses);
+        }
+    }
+}

--- a/src/test/java/com/yogpc/qp/machines/AreaTest.java
+++ b/src/test/java/com/yogpc/qp/machines/AreaTest.java
@@ -24,10 +24,23 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AreaTest {
     Area area = new Area(3, 4, 5, 9, 8, 7, Direction.UP);
+
+    @Test
+    void badArguments() {
+        assertAll(
+            () -> assertThrows(IllegalArgumentException.class, () ->
+                new Area(0, 0, 0, -1, 0, 0, Direction.UP)),
+            () -> assertThrows(IllegalArgumentException.class, () ->
+                new Area(0, 0, 0, 0, -1, 0, Direction.UP)),
+            () -> assertThrows(IllegalArgumentException.class, () ->
+                new Area(0, 0, 0, 0, 0, -1, Direction.UP))
+        );
+    }
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 3, 4})
@@ -165,6 +178,45 @@ class AreaTest {
         void intStreamTo5() {
             var array = Area.to(4, 4).toArray();
             assertArrayEquals(new int[]{4}, array);
+        }
+    }
+
+    @Nested
+    class ShrinkTest {
+        @Test
+        void shrinkX1() {
+            var shrunk = area.shrink(1, 0, 0);
+            assertEquals(new Area(4, 4, 5, 8, 8, 7, Direction.UP), shrunk);
+        }
+
+        @Test
+        void shrinkX3() {
+            var shrunk = area.shrink(3, 0, 0);
+            assertEquals(new Area(6, 4, 5, 6, 8, 7, Direction.UP), shrunk);
+        }
+
+        @Test
+        void shrinkX4() {
+            var shrunk = area.shrink(4, 0, 0);
+            assertEquals(new Area(5, 4, 5, 7, 8, 7, Direction.UP), shrunk);
+        }
+
+        @Test
+        void shrinkY1() {
+            var shrunk = area.shrink(0, 1, 0);
+            assertEquals(new Area(3, 5, 5, 9, 7, 7, Direction.UP), shrunk);
+        }
+
+        @Test
+        void shrinkY2() {
+            var shrunk = area.shrink(0, 2, 0);
+            assertEquals(new Area(3, 6, 5, 9, 6, 7, Direction.UP), shrunk);
+        }
+
+        @Test
+        void shrinkZ1() {
+            var shrunk = area.shrink(0, 0, 1);
+            assertEquals(new Area(3, 4, 6, 9, 8, 6, Direction.UP), shrunk);
         }
     }
 


### PR DESCRIPTION
Close #190 

This PR makes Quarry Plus and Chunk Destroyer not work in protected area. The "protected area" means claimed chunks by FTB Chunks, regardless the state of claimed chunk.

If you want to allow quarry's work in your claimed area, change the config option `allowWorkInClaimedChunkByFBTChunks`(default: `false`) to `true`. Then change the option of your team in FTB Teams(something related to Fake Players).

I don't provide a way to make "your" quarry work in your claimed area. "Your" quarry means the quarry you have placed. This is currently because of technical reason of saving player data.