### PR TITLE
1.18 excess energy

### DIFF
--- a/src/main/scala/com/yogpc/qp/machines/PowerTile.java
+++ b/src/main/scala/com/yogpc/qp/machines/PowerTile.java
@@ -43,7 +43,11 @@ public abstract class PowerTile extends BlockEntity implements IEnergyStorage {
             "%s(%d, %d, %d)".formatted(getClass().getSimpleName(), pos.getX(), pos.getY(), pos.getZ()));
         this.powerConfig = PowerConfig.getMachineConfig(Objects.requireNonNull(type.getRegistryName()).getPath());
         this.maxEnergy = this.powerConfig.maxEnergy();
-        setTimeProvider(() -> Objects.requireNonNull(this.level, "Level in block entity is null. Are you in test?").getGameTime());
+        setTimeProvider(() -> Objects.requireNonNull(this.level,
+            """
+                Level in block entity is null. Are you in test?
+                Make sure to run `setTimeProvider` to replace the default time provider."""
+        ).getGameTime());
     }
 
     @Override

--- a/src/main/scala/com/yogpc/qp/machines/quarry/TileQuarry.java
+++ b/src/main/scala/com/yogpc/qp/machines/quarry/TileQuarry.java
@@ -265,7 +265,8 @@ public class TileQuarry extends PowerTile implements CheckerLog, MachineStorage.
 
         // Break block
         var hardness = state.getDestroySpeed(targetWorld, targetPos);
-        if (requireEnergy && !useEnergy(PowerManager.getBreakEnergy(hardness, this), Reason.BREAK_BLOCK, false)) {
+        var requiredEnergy = PowerManager.getBreakEnergy(hardness, this);
+        if (requireEnergy && !useEnergy(requiredEnergy, Reason.BREAK_BLOCK, requiredEnergy > this.getMaxEnergy())) {
             return BreakResult.NOT_ENOUGH_ENERGY;
         }
         // Get drops


### PR DESCRIPTION
Close #201 

Quarries (Quarry Plus and Solid Fuel Quarry) now remove blocks which requires more energy than their energy capacity.

Example:
Before this patch is applied, SFQ(capacity: 1000 FE) wasn't able to remove Obsidian, which requires 1250 FE and caused deadlock.
After: SFQ removes Obsidian.
