### PR TITLE
1.19 Energy in Workbench screen

### DIFF
--- a/src/main/scala/com/yogpc/qp/machines/workbench/ScreenWorkbench.java
+++ b/src/main/scala/com/yogpc/qp/machines/workbench/ScreenWorkbench.java
@@ -26,7 +26,7 @@ public class ScreenWorkbench extends AbstractContainerScreen<ContainerWorkbench>
     @Override
     protected void renderLabels(PoseStack matrices, int mouseX, int mouseY) {
         super.renderLabels(matrices, mouseX, mouseY);
-        if (getMenu().tile.getMaxEnergyStored() != 0) {
+        if (getMenu().tile.getMaxEnergyStored() > 5) {
             String current = getMenu().tile.getEnergyStored() + "FE";
             this.font.draw(matrices, String.format("%s/%d", current, getMenu().tile.getMaxEnergyStored()),
                 120 - this.font.width(current), this.inventoryLabelY, 0x404040);

--- a/src/main/scala/com/yogpc/qp/machines/workbench/TileWorkbench.java
+++ b/src/main/scala/com/yogpc/qp/machines/workbench/TileWorkbench.java
@@ -251,7 +251,7 @@ public class TileWorkbench extends PowerTile implements Container, MenuProvider,
     public void setCurrentRecipe(ResourceLocation recipeName) {
         this.currentRecipe = recipesList.stream().filter(r -> recipeName.equals(r.getId()))
             .findFirst().orElse(WorkbenchRecipe.dummyRecipe());
-        setMaxEnergy(this.currentRecipe.getRequiredEnergy());
+        setMaxEnergy(Math.max(this.currentRecipe.getRequiredEnergy(), 5));
         if (QuarryPlus.config.common.noEnergy.get()) {
             setEnergy(0, true);
         }

--- a/src/test/java/com/yogpc/qp/machines/workbench/TileWorkbenchTest.java
+++ b/src/test/java/com/yogpc/qp/machines/workbench/TileWorkbenchTest.java
@@ -73,7 +73,7 @@ class TileWorkbenchTest {
         tile.updateRecipeList();
         assertEquals(5L, tile.getMaxEnergy() / PowerTile.ONE_FE); // Not updated yet.
         tile.setCurrentRecipe(new ResourceLocation(QuarryPlus.modID, "test_dirt2"));
-        assertEquals(0L, tile.getMaxEnergy());
+        assertEquals(5L, tile.getMaxEnergy(), "The default energy was changed to 0.");
         assertFalse(tile.getRecipe().hasContent());
     }
 


### PR DESCRIPTION
If the max energy of Workbench <= 5(initial state), it doesn't show the amount of energy in the tile.