### PR TITLE
1.19.2 chunk target

### DIFF
--- a/src/main/scala/com/yogpc/qp/machines/Area.java
+++ b/src/main/scala/com/yogpc/qp/machines/Area.java
@@ -142,8 +142,8 @@ public record Area(int minX, int minY, int minZ, int maxX, int maxY, int maxZ,
 
     public List<ChunkPos> getChunkPosList() {
         List<ChunkPos> posList = new ArrayList<>();
-        for (int x = this.minX / 16; x <= this.maxX / 16; x++) {
-            for (int z = this.minZ / 16; z <= this.maxZ / 16; z++) {
+        for (int x = Math.floorDiv(this.minX, 16); x <= Math.floorDiv(this.maxX, 16); x++) {
+            for (int z = Math.floorDiv(this.minZ, 16); z <= Math.floorDiv(this.maxZ, 16); z++) {
                 posList.add(new ChunkPos(x, z));
             }
         }

--- a/src/main/scala/com/yogpc/qp/machines/Area.java
+++ b/src/main/scala/com/yogpc/qp/machines/Area.java
@@ -2,6 +2,8 @@ package com.yogpc.qp.machines;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -11,6 +13,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.ChunkPos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -137,4 +140,13 @@ public record Area(int minX, int minY, int minZ, int maxX, int maxY, int maxZ,
                 new BlockPos(area.minX(), y, area.maxZ())));
     }
 
+    public List<ChunkPos> getChunkPosList() {
+        List<ChunkPos> posList = new ArrayList<>();
+        for (int x = this.minX / 16; x <= this.maxX / 16; x++) {
+            for (int z = this.minZ / 16; z <= this.maxZ / 16; z++) {
+                posList.add(new ChunkPos(x, z));
+            }
+        }
+        return posList;
+    }
 }

--- a/src/main/scala/com/yogpc/qp/machines/TargetIterator.java
+++ b/src/main/scala/com/yogpc/qp/machines/TargetIterator.java
@@ -17,10 +17,15 @@ public abstract class TargetIterator extends PickIterator<TargetIterator.XZPair>
         };
     }
 
+    public static TargetIterator of(Area area, boolean chunkByChunk) {
+        if (chunkByChunk) return new ChunkByChunk(area);
+        else return of(area);
+    }
+
     @Override
     public final boolean hasNext() {
         return area.minX() < current.x() && current.x() < area.maxX() &&
-            area.minZ() < current.z() && current.z() < area.maxZ();
+               area.minZ() < current.z() && current.z() < area.maxZ();
     }
 
     public record XZPair(int x, int z) {
@@ -111,6 +116,109 @@ public abstract class TargetIterator extends PickIterator<TargetIterator.XZPair>
         @Override
         public XZPair head() {
             return new XZPair(area.maxX() - 1, area.maxZ() - 1);
+        }
+    }
+
+    private static final class ChunkByChunk extends TargetIterator {
+
+        /**
+         * Exclusive.
+         * Area(1, 1, 1, 5, 1, 5) will create iterator from (2, 1, 2) to (4, 1, 4)
+         */
+        ChunkByChunk(Area area) {
+            super(area);
+        }
+
+        /*
+        In Python
+        def generate(first_pos, end_pos):
+            current = first_pos
+            max_pos = end_pos
+            current_chunk = current[0] // 16, current[1] // 16
+            first_chunk = current_chunk
+            max_chunk = max_pos[0] // 16, max_pos[1] // 16
+            yield current
+            while True:
+                # print(current)
+                max_chunk_x = min((current_chunk[0] + 1) * 16, max_pos[0])
+                if current[0] + 1 < max_chunk_x:
+                    current = current[0] + 1, current[1]
+                    yield current
+                    continue
+                # Change z
+                max_chunk_z = min((current_chunk[1] + 1) * 16, max_pos[1])
+                if current[1] + 1 < max_chunk_z:
+                    current = max(current_chunk[0] * 16, first_pos[0]), current[1] + 1
+                    yield current
+                    continue
+                # Change chunk X
+                if current_chunk[0] + 1 <= max_chunk[0]:
+                    current_chunk = current_chunk[0] + 1, current_chunk[1]
+                    current = max(current_chunk[0] * 16, first_pos[0]), max(current_chunk[1] * 16, first_pos[1])
+                    yield current
+                    continue
+                # Change chunk Z
+                if current_chunk[1] + 1 <= max_chunk[1]:
+                    current_chunk = first_chunk[0], current_chunk[1] + 1
+                    current = max(current_chunk[0] * 16, first_pos[0]), max(current_chunk[1] * 16, first_pos[1])
+                    yield current
+                    continue
+                # End?
+                print(current)
+                break
+         */
+        @Override
+        protected XZPair update() {
+            int currentChunkX = blockToSectionCoord(current.x());
+            int currentChunkZ = blockToSectionCoord(current.z());
+            var maxX = area.maxX() - 1;
+            var maxZ = area.maxZ() - 1;
+            var minX = area.minX() + 1;
+            var minZ = area.minZ() + 1;
+            if (current.x() + 1 <= Math.min(chunkToBlock(currentChunkX, 15), maxX)) {
+                // Move x
+                return new XZPair(current.x() + 1, current.z());
+            }
+            if (current.z() + 1 <= Math.min(chunkToBlock(currentChunkZ, 15), maxZ)) {
+                // Move z
+                // Reset x
+                return new XZPair(Math.max(chunkToBlock(currentChunkX, 0), minX), current.z() + 1);
+            }
+            if (currentChunkX + 1 <= blockToSectionCoord(maxX)) {
+                // Move chunk x
+                // Reset z
+                return new XZPair(
+                    Math.max(chunkToBlock(currentChunkX + 1, 0), minX),
+                    Math.max(chunkToBlock(currentChunkZ, 0), minZ));
+            }
+            if (currentChunkZ + 1 <= blockToSectionCoord(maxZ)) {
+                // Move chunk z
+                // Reset chunk x
+                return new XZPair(
+                    Math.max(chunkToBlock(blockToSectionCoord(minX), 0), minX),
+                    Math.max(chunkToBlock(currentChunkZ + 1, 0), minZ));
+            }
+            // End, returns dummy.
+            return new XZPair(current.x() + 1, current.z());
+        }
+
+        @Override
+        public XZPair head() {
+            return new XZPair(area.minX() + 1, area.minZ() + 1);
+        }
+
+        /**
+         * Copied from {@link net.minecraft.core.SectionPos#blockToSectionCoord(int)}
+         */
+        private static int blockToSectionCoord(int absolutePos) {
+            return absolutePos >> 4;
+        }
+
+        /**
+         * Copied from {@link net.minecraft.core.SectionPos#sectionToBlockCoord(int, int)}
+         */
+        private static int chunkToBlock(int chunk, int block) {
+            return (chunk << 4) + block;
         }
     }
 }

--- a/src/main/scala/com/yogpc/qp/machines/advquarry/AdvQuarryAction.java
+++ b/src/main/scala/com/yogpc/qp/machines/advquarry/AdvQuarryAction.java
@@ -82,6 +82,10 @@ public abstract class AdvQuarryAction implements BlockEntityTicker<TileAdvQuarry
         return null;
     }
 
+    TargetIterator createTargetIterator(Area area, boolean chunkByChunk) {
+        return TargetIterator.of(area, chunkByChunk);
+    }
+
     abstract static class Serializer {
         abstract String key();
 
@@ -219,12 +223,12 @@ public abstract class AdvQuarryAction implements BlockEntityTicker<TileAdvQuarry
 
         public BreakBlock(TileAdvQuarry quarry) {
             assert quarry.getArea() != null;
-            this.iterator = TargetIterator.of(quarry.getArea());
+            this.iterator = this.createTargetIterator(quarry.getArea(), quarry.chunkByChunk);
         }
 
         BreakBlock(TileAdvQuarry quarry, int x, int z, boolean searchEnergyConsumed) {
             assert quarry.getArea() != null;
-            this.iterator = TargetIterator.of(quarry.getArea());
+            this.iterator = this.createTargetIterator(quarry.getArea(), quarry.chunkByChunk);
             this.iterator.setCurrent(new TargetIterator.XZPair(x, z));
             this.searchEnergyConsumed = searchEnergyConsumed;
         }
@@ -288,12 +292,12 @@ public abstract class AdvQuarryAction implements BlockEntityTicker<TileAdvQuarry
 
         public CheckFluid(TileAdvQuarry quarry) {
             assert quarry.getArea() != null;
-            this.iterator = TargetIterator.of(quarry.getArea());
+            this.iterator = this.createTargetIterator(quarry.getArea(), quarry.chunkByChunk);
         }
 
         CheckFluid(TileAdvQuarry quarry, int x, int z) {
             assert quarry.getArea() != null;
-            this.iterator = TargetIterator.of(quarry.getArea());
+            this.iterator = this.createTargetIterator(quarry.getArea(), quarry.chunkByChunk);
             this.iterator.setCurrent(new TargetIterator.XZPair(x, z));
         }
 
@@ -393,12 +397,12 @@ public abstract class AdvQuarryAction implements BlockEntityTicker<TileAdvQuarry
 
         public FillerWork(TileAdvQuarry quarry) {
             assert quarry.getArea() != null;
-            this.iterator = TargetIterator.of(quarry.getArea());
+            this.iterator = this.createTargetIterator(quarry.getArea(), quarry.chunkByChunk);
         }
 
         FillerWork(TileAdvQuarry quarry, int x, int z) {
             assert quarry.getArea() != null;
-            this.iterator = TargetIterator.of(quarry.getArea());
+            this.iterator = this.createTargetIterator(quarry.getArea(), quarry.chunkByChunk);
             this.iterator.setCurrent(new TargetIterator.XZPair(x, z));
         }
 

--- a/src/main/scala/com/yogpc/qp/machines/advquarry/TileAdvQuarry.java
+++ b/src/main/scala/com/yogpc/qp/machines/advquarry/TileAdvQuarry.java
@@ -84,6 +84,7 @@ public class TileAdvQuarry extends PowerTile implements
     private Area area = null;
     private List<EnchantmentLevel> enchantments = List.of();
     private AdvQuarryAction action = AdvQuarryAction.Waiting.WAITING;
+    boolean chunkByChunk = false;
 
     public TileAdvQuarry(BlockPos pos, BlockState state) {
         super(Holder.ADV_QUARRY_TYPE, pos, state);
@@ -97,6 +98,7 @@ public class TileAdvQuarry extends PowerTile implements
             "%sAction:%s %s".formatted(ChatFormatting.GREEN, ChatFormatting.RESET, action),
             "%sRemoveBedrock:%s %s".formatted(ChatFormatting.GREEN, ChatFormatting.RESET, hasBedrockModule()),
             "%sDigMinY:%s %d".formatted(ChatFormatting.GREEN, ChatFormatting.RESET, digMinY),
+            "%sChunkByChunk:%s %b".formatted(ChatFormatting.GREEN, ChatFormatting.RESET, chunkByChunk),
             "%sModules:%s %s".formatted(ChatFormatting.GREEN, ChatFormatting.RESET, modules),
             energyString()
         ).map(Component::literal).toList();
@@ -151,6 +153,7 @@ public class TileAdvQuarry extends PowerTile implements
         nbt.put("enchantments", enchantments);
         nbt.putInt("digMinY", digMinY);
         nbt.put("action", action.toNbt());
+        nbt.putBoolean("chunkByChunk", chunkByChunk);
         return nbt;
     }
 
@@ -165,6 +168,7 @@ public class TileAdvQuarry extends PowerTile implements
             .toList());
         digMinY = nbt.getInt("digMinY");
         action = AdvQuarryAction.fromNbt(nbt.getCompound("action"), this);
+        chunkByChunk = nbt.getBoolean("chunkByChunk");
     }
 
     /**

--- a/src/test/java/com/yogpc/qp/machines/AreaTest.java
+++ b/src/test/java/com/yogpc/qp/machines/AreaTest.java
@@ -1,5 +1,9 @@
 package com.yogpc.qp.machines;
 
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -11,6 +15,8 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -134,8 +140,13 @@ class AreaTest {
     static Stream<Area> randomArea() {
         var random = RandomSource.create(564);
         return Stream.concat(Stream.generate(() ->
-                    new Area(new Vec3i(random.nextInt(), random.nextInt(), random.nextInt()),
-                        new Vec3i(random.nextInt(), random.nextInt(), random.nextInt()), Direction.getRandom(random)))
+                    new Area(new Vec3i(random.nextIntBetweenInclusive(-Level.MAX_LEVEL_SIZE, Level.MAX_LEVEL_SIZE),
+                        random.nextIntBetweenInclusive(-64, 256),
+                        random.nextIntBetweenInclusive(-Level.MAX_LEVEL_SIZE, Level.MAX_LEVEL_SIZE)),
+                        new Vec3i(random.nextIntBetweenInclusive(-Level.MAX_LEVEL_SIZE, Level.MAX_LEVEL_SIZE),
+                            random.nextIntBetweenInclusive(-64, 256),
+                            random.nextIntBetweenInclusive(-Level.MAX_LEVEL_SIZE, Level.MAX_LEVEL_SIZE)),
+                        Direction.getRandom(random)))
                 .limit(50),
             Stream.generate(() ->
                     new Area(new Vec3i(random.nextInt(1024) - 512, random.nextInt(1024) - 512, random.nextInt(1024) - 512),
@@ -242,8 +253,49 @@ class AreaTest {
         }
     }
 
+    @Nested
+    class GetChunkPosTest {
+        @Test
+        void test1() {
+            var chunks = area.getChunkPosList();
+            assertEquals(List.of(new ChunkPos(0, 0)), chunks);
+        }
+
+        @Test
+        void test2_1() {
+            var area = new Area(0, 0, 0, 31, 0, 0, Direction.NORTH);
+            assertEquals(List.of(new ChunkPos(0, 0), new ChunkPos(1, 0)), getChunkPosFromALL(area));
+        }
+
+        @ParameterizedTest
+        @MethodSource("areas")
+        void test(Area area) {
+            assertEquals(getChunkPosFromALL(area), area.getChunkPosList());
+        }
+
+        static List<ChunkPos> getChunkPosFromALL(Area area) {
+            Set<ChunkPos> posSet = new HashSet<>();
+            for (int x = area.minX(); x <= area.maxX(); x++) {
+                for (int z = area.minZ(); z <= area.maxZ(); z++) {
+                    posSet.add(new ChunkPos(new BlockPos(x, 0, z)));
+                }
+            }
+            return posSet.stream().sorted(Comparator.comparingInt(ChunkPos::getMinBlockX).thenComparingInt(ChunkPos::getMinBlockZ)).toList();
+        }
+
+        static Stream<Area> areas() {
+            return Stream.of(
+                new Area(0, 0, 0, 31, 0, 0, Direction.NORTH),
+                new Area(0, 0, 0, 32, 0, 0, Direction.NORTH),
+                new Area(0, 0, 0, 32, 0, 20, Direction.NORTH),
+                null
+            ).filter(Objects::nonNull);
+        }
+    }
+
     @Test
     void dummy() {
         assertTrue(randomArea().findAny().isPresent());
+        assertTrue(GetChunkPosTest.areas().findAny().isPresent());
     }
 }

--- a/src/test/java/com/yogpc/qp/machines/AreaTest.java
+++ b/src/test/java/com/yogpc/qp/machines/AreaTest.java
@@ -288,6 +288,8 @@ class AreaTest {
                 new Area(0, 0, 0, 31, 0, 0, Direction.NORTH),
                 new Area(0, 0, 0, 32, 0, 0, Direction.NORTH),
                 new Area(0, 0, 0, 32, 0, 20, Direction.NORTH),
+                new Area(-16, 0, 0, 15, 0, 0, Direction.NORTH),
+                new Area(-15, 0, 0, 15, 0, 0, Direction.NORTH),
                 null
             ).filter(Objects::nonNull);
         }

--- a/src/test/java/com/yogpc/qp/machines/TargetIteratorTest.java
+++ b/src/test/java/com/yogpc/qp/machines/TargetIteratorTest.java
@@ -11,9 +11,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(QuarryPlusTest.class)
 class TargetIteratorTest {
@@ -374,6 +377,49 @@ class TargetIteratorTest {
                 new TargetIterator.XZPair(-10, -31)
             );
             assertIterableEquals(expected, list);
+        }
+
+        @Test
+        @DisplayName("(0, 0) -> (16, 16), end exclusive")
+        void oneChunk1() {
+            // (0, 0) -> (16, 16), end exclusive
+            Area area = new Area(-1, 0, -1, 16, 0, 16, Direction.NORTH);
+            Iterable<TargetIterator.XZPair> iterable = () -> TargetIterator.of(area, true);
+            var list = assertTimeout(Duration.ofSeconds(3), () -> StreamSupport.stream(iterable.spliterator(), false).toList());
+            assertAll(
+                () -> assertEquals(new TargetIterator.XZPair(0, 0), list.get(0)),
+                () -> assertFalse(list.contains(new TargetIterator.XZPair(16, 16))),
+                () -> assertEquals(256, list.size())
+            );
+        }
+
+        @Test
+        @DisplayName("(0, 0) -> (15, 15), end exclusive")
+        void oneChunk2() {
+            // (0, 0) -> (15, 15), end exclusive
+            Area area = new Area(-1, 0, -1, 15, 0, 15, Direction.NORTH);
+            Iterable<TargetIterator.XZPair> iterable = () -> TargetIterator.of(area, true);
+            var list = assertTimeout(Duration.ofSeconds(3), () -> StreamSupport.stream(iterable.spliterator(), false).toList());
+            assertAll(
+                () -> assertEquals(new TargetIterator.XZPair(0, 0), list.get(0)),
+                () -> assertFalse(list.contains(new TargetIterator.XZPair(15, 15))),
+                () -> assertEquals(225, list.size())
+            );
+        }
+
+        @Test
+        @DisplayName("(0, 0) -> (17, 17), end exclusive")
+        void oneChunk3() {
+            // (0, 0) -> (17, 17), end exclusive
+            Area area = new Area(-1, 0, -1, 17, 0, 17, Direction.NORTH);
+            Iterable<TargetIterator.XZPair> iterable = () -> TargetIterator.of(area, true);
+            var list = assertTimeout(Duration.ofSeconds(3), () -> StreamSupport.stream(iterable.spliterator(), false).toList());
+            assertAll(
+                () -> assertEquals(new TargetIterator.XZPair(0, 0), list.get(0)),
+                () -> assertTrue(list.contains(new TargetIterator.XZPair(16, 16))),
+                () -> assertFalse(list.contains(new TargetIterator.XZPair(17, 17))),
+                () -> assertEquals(289, list.size())
+            );
         }
     }
 }


### PR DESCRIPTION
Related to #240

Currently, Chunk Destroyer removes blocks crossing chunk boundary, removes from min X to max X and go next Z.
This PR add a new option, chunk wise target. It removes all blocks in the chunk and go next chunk. It may reduce lag of generating new chunk if the target chunk is not generated yet.

In this PR, there is no option to use new target in real environment. Further PR will enable in-game setting.