### PR TITLE
1.21 Allow Anvil to move enchantment to machines

### DIFF
--- a/common/src/gameTest/java/com/yogpc/qp/machine/mover/PlaceMoverTest.java
+++ b/common/src/gameTest/java/com/yogpc/qp/machine/mover/PlaceMoverTest.java
@@ -3,8 +3,10 @@ package com.yogpc.qp.machine.mover;
 import com.yogpc.qp.PlatformAccess;
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.EnchantmentInstance;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.GameType;
 
@@ -87,6 +89,25 @@ public final class PlaceMoverTest {
         helper.assertItemEntityPresent(PlatformAccess.getAccess().registerObjects().moverBlock().get().blockItem, base, 4);
         helper.assertItemEntityPresent(Items.DIAMOND_PICKAXE, base, 4);
         helper.assertItemEntityPresent(PlatformAccess.getAccess().registerObjects().quarryBlock().get().blockItem, base, 4);
+        helper.succeed();
+    }
+
+    public static void moveFromEnchantedBook(GameTestHelper helper) {
+        helper.setBlock(base, PlatformAccess.getAccess().registerObjects().moverBlock().get());
+        MoverEntity mover = helper.getBlockEntity(base);
+
+        var enchantment = getEnchantment(helper, Enchantments.EFFICIENCY);
+        var stack = EnchantedBookItem.createForEnchantment(new EnchantmentInstance(enchantment, 1));
+        var quarry = new ItemStack(PlatformAccess.getAccess().registerObjects().quarryBlock().get());
+        mover.inventory.setItem(0, stack);
+        mover.inventory.setItem(1, quarry);
+
+        mover.moveEnchant(enchantment);
+        assertAll(
+            () -> assertEquals(1, quarry.getEnchantments().getLevel(enchantment)),
+            () -> assertTrue(mover.inventory.getItem(0).isEmpty()),
+            () -> assertTrue(mover.movableEnchantments.isEmpty())
+        );
         helper.succeed();
     }
 }

--- a/common/src/main/java/com/yogpc/qp/machine/mover/MoverEntity.java
+++ b/common/src/main/java/com/yogpc/qp/machine/mover/MoverEntity.java
@@ -15,14 +15,12 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.SimpleContainer;
-import net.minecraft.world.item.BowItem;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TieredItem;
-import net.minecraft.world.item.Tiers;
+import net.minecraft.world.item.*;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.block.state.BlockState;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -86,6 +84,9 @@ public final class MoverEntity extends QpEntity implements ClientSync {
         public boolean canPlaceItem(int slot, ItemStack stack) {
             return switch (slot) {
                 case 0 -> {
+                    if (stack.getItem() instanceof EnchantedBookItem) {
+                        yield true;
+                    }
                     if (!stack.isEnchanted()) {
                         yield false;
                     }
@@ -147,34 +148,44 @@ public final class MoverEntity extends QpEntity implements ClientSync {
     }
 
     void moveEnchant(Holder<Enchantment> enchantment) {
-        moveEnchantment(enchantment, inventory.getItem(0), inventory.getItem(1), this::updateMovableEnchantments);
+        var moved = moveEnchantment(enchantment, inventory.getItem(0), inventory.getItem(1), this::updateMovableEnchantments);
+        inventory.setItem(0, moved.getLeft());
+        inventory.setItem(1, moved.getRight());
     }
 
-    static void moveEnchantment(@Nullable Holder<Enchantment> enchantment, ItemStack from, ItemStack to, Runnable after) {
-        moveEnchantment(enchantment, from, to, null, after);
+    static Pair<ItemStack, ItemStack> moveEnchantment(@Nullable Holder<Enchantment> enchantment, ItemStack from, ItemStack to, Runnable after) {
+        return moveEnchantment(enchantment, from, to, null, after);
     }
 
     @VisibleForTesting
-    static void moveEnchantment(@Nullable Holder<Enchantment> enchantment, ItemStack from, ItemStack to, @Nullable Predicate<Holder<Enchantment>> predicate, Runnable after) {
-        if (enchantment == null || from.isEmpty() || to.isEmpty()) return;
+    static Pair<ItemStack, ItemStack> moveEnchantment(@Nullable Holder<Enchantment> enchantment, ItemStack from, ItemStack to, @Nullable Predicate<Holder<Enchantment>> predicate, Runnable after) {
+        if (enchantment == null || from.isEmpty() || to.isEmpty()) return Pair.of(from, to);
         if (canMoveEnchantment(predicate, EnchantmentHelper.getEnchantmentsForCrafting(to), enchantment)) {
-            upLevel(enchantment, to);
-            downLevel(enchantment, from);
+            var right = upLevel(enchantment, to);
+            var left = downLevel(enchantment, from);
             after.run();
+            return Pair.of(left, right);
         }
+        return Pair.of(from, to);
     }
 
     @VisibleForTesting
-    static void downLevel(Holder<Enchantment> enchantment, ItemStack stack) {
+    static ItemStack downLevel(Holder<Enchantment> enchantment, ItemStack stack) {
         EnchantmentHelper.updateEnchantments(stack, mutable ->
             mutable.set(enchantment, mutable.getLevel(enchantment) - 1)
         );
+        if (stack.is(Items.ENCHANTED_BOOK) && EnchantmentHelper.getEnchantmentsForCrafting(stack).isEmpty()) {
+            // Remove empty enchanted book
+            return ItemStack.EMPTY;
+        }
+        return stack;
     }
 
     @VisibleForTesting
-    static void upLevel(Holder<Enchantment> enchantment, ItemStack stack) {
+    static ItemStack upLevel(Holder<Enchantment> enchantment, ItemStack stack) {
         EnchantmentHelper.updateEnchantments(stack, mutable ->
             mutable.set(enchantment, mutable.getLevel(enchantment) + 1)
         );
+        return stack;
     }
 }

--- a/fabric/game-test/server.properties
+++ b/fabric/game-test/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Sun Dec 01 00:54:35 JST 2024
+#Sat Dec 07 23:11:08 JST 2024
 accepts-transfers=false
 allow-flight=true
 allow-nether=true

--- a/fabric/game-test/server.properties
+++ b/fabric/game-test/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Sat Dec 07 23:11:08 JST 2024
+#Sun Dec 08 00:31:24 JST 2024
 accepts-transfers=false
 allow-flight=true
 allow-nether=true

--- a/fabric/src/gameTest/java/com/yogpc/qp/fabric/EnchantmentTest.java
+++ b/fabric/src/gameTest/java/com/yogpc/qp/fabric/EnchantmentTest.java
@@ -1,0 +1,38 @@
+package com.yogpc.qp.fabric;
+
+import com.yogpc.qp.PlatformAccess;
+import com.yogpc.qp.gametest.GameTestFunctions;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantments;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public final class EnchantmentTest implements FabricGameTest {
+
+    @GameTest(template = EMPTY_STRUCTURE)
+    public void quarryEnchantmentEfficiency(GameTestHelper helper) {
+        var enchantment = GameTestFunctions.getEnchantment(helper, Enchantments.EFFICIENCY);
+        var stack = new ItemStack(PlatformAccess.getAccess().registerObjects().quarryBlock().get());
+        assertTrue(enchantment.value().canEnchant(stack));
+        helper.succeed();
+    }
+
+    @GameTest(template = EMPTY_STRUCTURE)
+    public void quarryEnchantmentUnbreaking(GameTestHelper helper) {
+        var enchantment = GameTestFunctions.getEnchantment(helper, Enchantments.UNBREAKING);
+        var stack = new ItemStack(PlatformAccess.getAccess().registerObjects().quarryBlock().get());
+        assertTrue(enchantment.value().canEnchant(stack));
+        helper.succeed();
+    }
+
+    @GameTest(template = EMPTY_STRUCTURE)
+    public void quarryEnchantmentFortune(GameTestHelper helper) {
+        var enchantment = GameTestFunctions.getEnchantment(helper, Enchantments.FORTUNE);
+        var stack = new ItemStack(PlatformAccess.getAccess().registerObjects().quarryBlock().get());
+        assertTrue(enchantment.value().canEnchant(stack));
+        helper.succeed();
+    }
+}

--- a/fabric/src/gameTest/java/com/yogpc/qp/fabric/LoadTest.java
+++ b/fabric/src/gameTest/java/com/yogpc/qp/fabric/LoadTest.java
@@ -47,6 +47,7 @@ public final class LoadTest implements FabricGameTest {
             field.setAccessible(true);
             var map = (Map<Class<?>, String>) field.get(null);
             map.put(LoadTest.class, QuarryPlus.modID);
+            map.put(EnchantmentTest.class, QuarryPlus.modID);
 
             GameTestRegistry.register(LoadTest.class);
             QuarryPlus.LOGGER.info("Registered GameTest for Fabric");

--- a/fabric/src/main/java/com/yogpc/qp/fabric/mixin/MixinEnchantment.java
+++ b/fabric/src/main/java/com/yogpc/qp/fabric/mixin/MixinEnchantment.java
@@ -1,0 +1,20 @@
+package com.yogpc.qp.fabric.mixin;
+
+import com.yogpc.qp.machine.advquarry.AdvQuarryItem;
+import com.yogpc.qp.machine.quarry.QuarryItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Enchantment.class)
+public abstract class MixinEnchantment {
+    @Inject(method = "canEnchant", at = @At("HEAD"), cancellable = true)
+    public void canEnchant(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+        if (stack.getItem() instanceof QuarryItem || stack.getItem() instanceof AdvQuarryItem) {
+            cir.setReturnValue(stack.getCount() == 1);
+        }
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -33,6 +33,7 @@
     ]
   },
   "mixins": [
+    "quarryplus.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.16.0",

--- a/fabric/src/main/resources/quarryplus.mixins.json
+++ b/fabric/src/main/resources/quarryplus.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "package": "com.yogpc.qp.fabric.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "MixinEnchantment"
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/forge/game-test/server.properties
+++ b/forge/game-test/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Sun Dec 01 00:54:38 JST 2024
+#Sat Dec 07 23:11:09 JST 2024
 accepts-transfers=false
 allow-flight=true
 allow-nether=true

--- a/forge/game-test/server.properties
+++ b/forge/game-test/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Sat Dec 07 23:11:09 JST 2024
+#Sun Dec 08 00:31:26 JST 2024
 accepts-transfers=false
 allow-flight=true
 allow-nether=true

--- a/neoforge/game-test/server.properties
+++ b/neoforge/game-test/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Sat Dec 07 23:11:33 JST 2024
+#Sun Dec 08 00:31:25 JST 2024
 accepts-transfers=false
 allow-flight=true
 allow-nether=true

--- a/neoforge/game-test/server.properties
+++ b/neoforge/game-test/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Sun Dec 01 00:54:36 JST 2024
+#Sat Dec 07 23:11:33 JST 2024
 accepts-transfers=false
 allow-flight=true
 allow-nether=true


### PR DESCRIPTION
Close #733 

This PR allows Fabric users to use Anvil to move enchantments from Enchanted Book to machines. For Forge and NeoForge users, use Enchantment Mover to move enchantments. Anvil doesn't work in Survival.