### PR TITLE
Fix Neoforge 21.5.81 compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ minecraft = "1.21.5"
 forge = "1.21.5-55.0.23"
 fabric_api = "0.128.1+1.21.5"
 fabric_loader = "0.16.14"
-neoforge = "21.5.78"
+neoforge = "21.5.81"
 fabric_version_checker = "2.5.0"
 
 du = "21.5.3"

--- a/neoforge/src/main/java/com/yogpc/qp/neoforge/QuarryPlusClientNeoForge.java
+++ b/neoforge/src/main/java/com/yogpc/qp/neoforge/QuarryPlusClientNeoForge.java
@@ -24,7 +24,7 @@ import net.neoforged.neoforge.client.event.RegisterMenuScreensEvent;
 public final class QuarryPlusClientNeoForge {
     @SubscribeEvent
     public static void clientInit(FMLClientSetupEvent event) {
-        QuarryPlus.LOGGER.info("Initialize Client({})", event.description());
+        QuarryPlus.LOGGER.info("Initialize Client");
         BlockEntityRenderers.register(PlatformAccessNeoForge.RegisterObjectsNeoForge.QUARRY_ENTITY_TYPE.get(), RenderQuarryNeoForge::new);
         BlockEntityRenderers.register(PlatformAccessNeoForge.RegisterObjectsNeoForge.MARKER_ENTITY_TYPE.get(), RenderMarkerNeoForge::new);
         BlockEntityRenderers.register(PlatformAccessNeoForge.RegisterObjectsNeoForge.FLEXIBLE_MARKER_ENTITY_TYPE.get(), RenderFlexibleMarkerNeoForge::new);


### PR DESCRIPTION
FMLClientSetupEvent.description() appears to have been removed so I have removed the reference to it.