### PR TITLE
Perf: resolve ServiceLoader implementations once instead of per call

### DIFF
--- a/common/src/main/java/com/yogpc/qp/machine/MachineStorage.java
+++ b/common/src/main/java/com/yogpc/qp/machine/MachineStorage.java
@@ -36,10 +36,23 @@ public class MachineStorage {
     protected final Object2LongLinkedOpenHashMap<FluidKey> fluids = new Object2LongLinkedOpenHashMap<>();
     List<Runnable> onUpdate = new ArrayList<>();
 
+    /**
+     * The implementation is provided via a static service file, so it is resolved once and reused.
+     * This method is called for every machine and for every entry decoded from NBT, so the
+     * {@link ServiceLoader} scan it used to perform was far from free.
+     */
+    private static final class FactoryHolder {
+        private FactoryHolder() {
+        }
+
+        static final MachineStorageFactory FACTORY =
+            ServiceLoader.load(MachineStorageFactory.class, MachineStorageFactory.class.getClassLoader())
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Could not find Machine Storage implementation"));
+    }
+
     public static MachineStorage of() {
-        var factory = ServiceLoader.load(MachineStorageFactory.class, MachineStorageFactory.class.getClassLoader())
-            .findFirst().orElseThrow(() -> new IllegalStateException("Could not find Machine Storage implementation"));
-        return factory.createMachineStorage();
+        return FactoryHolder.FACTORY.createMachineStorage();
     }
 
     static MachineStorage of(Map<ItemKey, Long> items, Map<FluidKey, Long> fluids) {

--- a/common/src/main/java/com/yogpc/qp/machine/MachineStorageHolder.java
+++ b/common/src/main/java/com/yogpc/qp/machine/MachineStorageHolder.java
@@ -1,5 +1,6 @@
 package com.yogpc.qp.machine;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
@@ -8,13 +9,28 @@ public interface MachineStorageHolder<T> {
 
     Class<T> supportingClass();
 
+    /**
+     * Service providers are declared in static resource files, so they never change at runtime.
+     * Resolving them once avoids a {@link ServiceLoader} scan (class loading + service file parsing)
+     * on every invocation.
+     */
+    final class Providers {
+        private Providers() {
+        }
+
+        static final List<MachineStorageHolder<?>> HOLDERS =
+            ServiceLoader.load(MachineStorageHolder.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .toList();
+    }
+
     @SuppressWarnings("unchecked")
     static <T> Optional<MachineStorageHolder<T>> getHolder(T object) {
         if (object == null) {
             return Optional.empty();
         }
 
-        for (MachineStorageHolder<?> holder : ServiceLoader.load(MachineStorageHolder.class)) {
+        for (MachineStorageHolder<?> holder : Providers.HOLDERS) {
             if (holder.supportingClass().isAssignableFrom(object.getClass())) {
                 return Optional.of((MachineStorageHolder<T>) holder);
             }


### PR DESCRIPTION
## Summary
`MachineStorage.of()` ran `ServiceLoader.load()` on every call. It is invoked for every machine instance and for every `MachineStorage` entry decoded from NBT, and the providers are declared in static service files, so the lookup can be done once and reused.

`MachineStorageHolder.getHolder()` runs on hot paths (per tick and per item slot interaction) and scanned the service loader on every invocation. Cache the resolved holder list in a holder class initialised once.

## Changes
- `MachineStorage`: resolve the factory once in a static holder instead of per `of()` call.
- `MachineStorageHolder`: cache the resolved holders, first matching `supportingClass()` wins (same order semantics as before).

## Behaviour
Both changes keep the exact same resolution semantics while removing repeated class loading and service-file parsing. No observable behaviour change.